### PR TITLE
Update Cluster_doc.ecl

### DIFF
--- a/ML/Tests/Benchmarks/Cluster_doc.ecl
+++ b/ML/Tests/Benchmarks/Cluster_doc.ecl
@@ -11,9 +11,8 @@
 
 IMPORT ML;
 
-lMatrix:={UNSIGNED id;REAL x;REAL y;};
+lMatrix:=ML.Types.NumericField;
 
-/*
 dDocumentMatrix:=DATASET([
 {1,2.4639,7.8579},
 {2,0.5573,9.4681},
@@ -116,21 +115,21 @@ dDocumentMatrix:=DATASET([
 {99,3.6239,5.3696},
 {100,3.2393,3.0533}
 ],lMatrix);
-*/
-dDocumentMatrix := DATASET('~tmp::keren::randomTest',{UNSIGNED ID, REAL A, REAL B, REAL C, REAL D, REAL E}, Flat);
+
+// dDocumentMatrix := DATASET('~tmp::keren::randomTest',{UNSIGNED ID, REAL A, REAL B, REAL C, REAL D, REAL E}, Flat);
 
 dCentroidMatrix:=DATASET([
-{1,1,1,1,1,1},
-{2,2,2,2,2,2},
-{3,3,3,3,3,3},
-{4,4,4,4,4,4}
-],{UNSIGNED ID, REAL A, REAL B, REAL C, REAL D, REAL E});
+                          {1,1,1,1,1,1},
+                          {2,2,2,2,2,2},
+                          {3,3,3,3,3,3},
+                          {4,4,4,4,4,4}
+                          ],{UNSIGNED ID, REAL A, REAL B, REAL C, REAL D, REAL E});
 
 //ML.ToField(dDocumentMatrix,dDocuments);
 ML.ToField(dCentroidMatrix,dCentroids);
 
                                                          // EXAMPLES
-KMeans:=ML.Cluster.KMeans(dDocumentsMatrix,dCentroids,30,.3);  // Set up KMeans with a maximum of 30 iterations and .3 as a convergence threshold
+KMeans:=ML.Cluster.KMeans(dDocumentMatrix,dCentroids,30,.3);  // Set up KMeans with a maximum of 30 iterations and .3 as a convergence threshold
 KMeans.Allresults;                                       // The table that contains the results of each iteration
 KMeans.Convergence;                                      // The number of iterations it took to converge
 KMeans.Result(12);                                       // The results of iteration 12
@@ -139,5 +138,3 @@ KMeans.Delta(0);                                         // The total distance t
 KMeans.DistanceDelta(5,15);                              // The straight-line distance travelled by each centroid from iterations 5 to 15
 KMeans.DistanceDelta(0);                                 // The total straight-line distance each centroid travelled 
 KMeans.DistanceDelta();                                  // The distance travelled by each centroid during the last iteration.
-
-


### PR DESCRIPTION
See ML-247 
In the ML\Tests\Benchmarks folder, the cluster_doc.ecl file included in the latest ML download generates syntax errors due to a typo in the ML.Cluster.KMeans near line 132. In addition, the DATASET referenced on Line 119 is a sprayed file that does not exist. If you comment out that line and uncomment the inline DATASET, and then change the lMatrix definition on line 14 to:

lMatrix:=ML.Types.NumericField;

The example will compile and execute correctly.

I have pushed the corrected code.